### PR TITLE
fix: prevent infinite comment loop when bot mentions itself

### DIFF
--- a/actions/release-management/actions/comment.js
+++ b/actions/release-management/actions/comment.js
@@ -23,15 +23,19 @@ function createAction (serviceLocator) {
           if (ghAction !== 'created') {
             return cb(null, false)
           }
-          // If the comment contains a trigger phrase then we are good to go
-          if (checkTriggerPhrase(comment.body)) {
-            return cb(null, true)
-          }
           var suffix = '@' + serviceLocator.authedUser.username + ' '
             , repoManager = serviceLocator.repoManager(comment.repoOwner, comment.repoName)
           // Ignore anything that isn't directly trying to communicate with the bot
           if (comment.body.indexOf(suffix) === -1) {
             return cb(null, false)
+          }
+          // Ignore anything that is the bot commenting with a comment that includes @itself
+          if (comment.author === serviceLocator.authedUser.username) {
+            return cb(null, false)
+          }
+          // If the comment contains a trigger phrase then we are good to go
+          if (checkTriggerPhrase(comment.body)) {
+            return cb(null, true)
           }
           // Otherwise, let the user know the command is unknown
           repoManager.getPull(comment.issueNumber, function (error, pr) {

--- a/actions/release-management/test/actions/comment.test.js
+++ b/actions/release-management/test/actions/comment.test.js
@@ -5,7 +5,12 @@ var assert = require('assert')
 describe('release-management comment action', function () {
 
   it('should pass check when github action is "created" comment contains trigger phrase', function (done) {
-    var action = createAction({ authedUser: { username: 'test' } })
+    var sl =
+      { authedUser: { username: 'test' }
+        , repoManager: function () {
+        }
+      }
+      , action = createAction(sl)
     action.check('created', { body: '@test add to release' }, function (error, shouldExec) {
       if (error) return done(error)
       assert.equal(shouldExec, true, 'shouldExec should be true')
@@ -16,6 +21,20 @@ describe('release-management comment action', function () {
   it('should not pass check when github action is not "created"', function (done) {
     var action = createAction({ authedUser: { username: 'test' } })
     action.check('opened', { body: '@test add to release' }, function (error, shouldExec) {
+      if (error) return done(error)
+      assert.equal(shouldExec, false, 'shouldExec should be false')
+      done()
+    })
+  })
+
+  it('should not pass check comment includes bot and is created by bot', function (done) {
+    var sl =
+      { authedUser: { username: 'test' }
+        , repoManager: function () {
+        }
+      }
+      , action = createAction(sl)
+    action.check('created', { body: '@test add to release', author: 'test' }, function (error, shouldExec) {
       if (error) return done(error)
       assert.equal(shouldExec, false, 'shouldExec should be false')
       done()


### PR DESCRIPTION
Alternative fix: require the bot @ to be at the very start of the message

![image](https://user-images.githubusercontent.com/6363719/194523516-4ff368e4-58bc-4278-986a-8afaab1f9b2c.png)
